### PR TITLE
Update origami build tools (breaking)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
   "dependencies": {
     "del": "^1.1.1",
     "gulp-watch": "^5.0.0",
-    "origami-build-tools": "^7.0.0",
+    "origami-build-tools": "^8.1.0",
     "request": "^2.69.0"
+  },
+  "engines": {
+    "node": ">=8"
   }
 }


### PR DESCRIPTION
* breaking change is that you have to use node 8, node 6 is no longer supported